### PR TITLE
PAYS-67 - Fixing by Adding not null check to resolve the GET saving account by ID api failure

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsProductData.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsProductData.java
@@ -598,11 +598,13 @@ public final class SavingsProductData implements Serializable {
     }
 
     public boolean isUpfrontAccrualAccounting() {
-        return this.accountingRule != null && AccountingRuleType.ACCRUAL_UPFRONT.getValue().toString().equals(this.accountingRule.getValue());
+        return this.accountingRule != null
+                && AccountingRuleType.ACCRUAL_UPFRONT.getValue().toString().equals(this.accountingRule.getValue());
     }
 
     public boolean isPeriodicAccrualAccounting() {
-        return this.accountingRule != null && AccountingRuleType.ACCRUAL_PERIODIC.getValue().toString().equals(this.accountingRule.getValue());
+        return this.accountingRule != null
+                && AccountingRuleType.ACCRUAL_PERIODIC.getValue().toString().equals(this.accountingRule.getValue());
     }
 
 }

--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsProductData.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsProductData.java
@@ -590,7 +590,7 @@ public final class SavingsProductData implements Serializable {
     }
 
     public boolean isCashBasedAccountingEnabled() {
-        return AccountingRuleType.CASH_BASED.getValue().toString().equals(this.accountingRule.getValue());
+        return this.accountingRule != null && AccountingRuleType.CASH_BASED.getValue().toString().equals(this.accountingRule.getValue());
     }
 
     public boolean isAccrualBasedAccountingEnabled() {
@@ -598,11 +598,11 @@ public final class SavingsProductData implements Serializable {
     }
 
     public boolean isUpfrontAccrualAccounting() {
-        return AccountingRuleType.ACCRUAL_UPFRONT.getValue().toString().equals(this.accountingRule.getValue());
+        return this.accountingRule != null && AccountingRuleType.ACCRUAL_UPFRONT.getValue().toString().equals(this.accountingRule.getValue());
     }
 
     public boolean isPeriodicAccrualAccounting() {
-        return AccountingRuleType.ACCRUAL_PERIODIC.getValue().toString().equals(this.accountingRule.getValue());
+        return this.accountingRule != null && AccountingRuleType.ACCRUAL_PERIODIC.getValue().toString().equals(this.accountingRule.getValue());
     }
 
 }


### PR DESCRIPTION
## Description

Adding not null check to resolve the GET saving account by ID api failure with error "Cannot invoke "org.apache.fineract.infrastructure.core.data.EnumOptionData.getValue()" because "this.accountingRule" is null (through reference chain: org.apache.fineract.portfolio.savings.data.SavingsAccountData["productOptions"]->java.util.ArrayList[0]->org.apache.fineract.portfolio.savings.data.SavingsProductData["periodicAccrualAccounting"])

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update unit or integration tests for verifying the changes made.
- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
