### PR TITLE
[Revamp-Kafka Setup] fix: allow Kafka extra-properties to support SAS…

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/config/FineractProperties.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/config/FineractProperties.java
@@ -250,13 +250,14 @@ public class FineractProperties {
             if (StringUtils.isNotEmpty(getExtraProperties()) && validateSeparators()) {
                 String[] lines = StringUtils.split(getExtraProperties(), extraPropertiesSeparator);
                 Arrays.stream(lines).forEach(line -> {
-                    String[] keyAndValue = StringUtils.split(line, extraPropertiesKeyValueSeparator);
-                    if (keyAndValue.length == 2) {
-                        map.put(keyAndValue[0], keyAndValue[1]);
+                    int index = line.indexOf(extraPropertiesKeyValueSeparator);
+                    if (index > 0 && index < line.length() - 1) {
+                        String key = line.substring(0, index);
+                        String value = line.substring(index + 1);
+                        map.put(key, value);
                     } else {
                         log.warn("Invalid property: {}", line);
                     }
-
                 });
             }
             return map;

--- a/fineract-core/src/test/java/org/apache/fineract/infrastructure/core/config/FineractPropertiesTest.java
+++ b/fineract-core/src/test/java/org/apache/fineract/infrastructure/core/config/FineractPropertiesTest.java
@@ -33,12 +33,20 @@ class FineractPropertiesTest {
         testKafkaPropertiesParse("|", "=", "key1=value1", Map.of("key1", "value1"));
         testKafkaPropertiesParse("|", "=", "key1=value1|key2=value2", Map.of("key1", "value1", "key2", "value2"));
         testKafkaPropertiesParse(";", ":", "key1:value1;key2:value2", Map.of("key1", "value1", "key2", "value2"));
+        // value containing additional '=' characters (e.g. sasl.jaas.config)
+        testKafkaPropertiesParse("|", "=",
+                "sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"user\" password=\"pass\";",
+                Map.of("sasl.jaas.config",
+                        "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"user\" password=\"pass\";"));
 
         // invalid configs
         testKafkaPropertiesParse("||", "=", "key1=value1", Map.of());
         testKafkaPropertiesParse("|", "", "key1=value1", Map.of());
         testKafkaPropertiesParse("", "", "key1=value1", Map.of());
-        testKafkaPropertiesParse("|", "=", "key1=value1=value2", Map.of());
+        // still treat entries without a key or value as invalid
+        testKafkaPropertiesParse("|", "=", "invalid", Map.of());
+        // multi '=' is now valid: everything after the first '=' is the value
+        testKafkaPropertiesParse("|", "=", "key1=value1=value2", Map.of("key1", "value1=value2"));
     }
 
     private void testKafkaPropertiesParse(String lineSep, String keyValueSep, String property, Map<String, String> expected) {


### PR DESCRIPTION
…L JAAS configs

Parse Kafka extra-properties by first = to keep values with additional = (e.g. sasl.jaas.config) Add unit coverage for KafkaProperties parsing and run Spotless to align formatting

## Description

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update unit or integration tests for verifying the changes made.
- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
