### PR TITLE
[FSP-28] Add running balance calculation for EMT levy transactions

### DIFF
--- a/custom/paystack/portfolio/account/src/main/java/com/paystack/fineract/portfolio/account/service/PaystackSavingsAccountDomainServiceJpa.java
+++ b/custom/paystack/portfolio/account/src/main/java/com/paystack/fineract/portfolio/account/service/PaystackSavingsAccountDomainServiceJpa.java
@@ -784,7 +784,15 @@ public class PaystackSavingsAccountDomainServiceJpa extends SavingsAccountDomain
             account.getSummary().updateSummaryWithPivotConfig(account.getCurrency(), savingsAccountTransactionSummaryWrapper, levyTxn,
                     account.getSavingsAccountTransactionsWithPivotConfig());
         } else {
+            // Calculate and set running balance for non-backdated transactions
+            // EMT Levy is a debit transaction, so we subtract from current balance
+            Money currentBalance = Money.of(account.getCurrency(), account.getAccountBalance());
+            Money newRunningBalance = currentBalance.minus(levyMoney);
+            levyTxn.setRunningBalance(newRunningBalance);
             account.addTransaction(levyTxn);
+            // Update account summary to reflect the EMT levy deduction
+            account.getSummary().updateSummaryWithPivotConfig(account.getCurrency(), savingsAccountTransactionSummaryWrapper, levyTxn,
+                    account.getTransactions());
         }
 
         saveTransactionToGenerateTransactionId(levyTxn);

--- a/custom/paystack/portfolio/account/src/main/java/com/paystack/fineract/portfolio/account/service/PaystackSavingsAccountDomainServiceJpa.java
+++ b/custom/paystack/portfolio/account/src/main/java/com/paystack/fineract/portfolio/account/service/PaystackSavingsAccountDomainServiceJpa.java
@@ -791,8 +791,7 @@ public class PaystackSavingsAccountDomainServiceJpa extends SavingsAccountDomain
             levyTxn.setRunningBalance(newRunningBalance);
             account.addTransaction(levyTxn);
             // Update account summary to reflect the EMT levy deduction
-            account.getSummary().updateSummaryWithPivotConfig(account.getCurrency(), savingsAccountTransactionSummaryWrapper, levyTxn,
-                    account.getTransactions());
+            account.getSummary().updateSummary(account.getCurrency(), savingsAccountTransactionSummaryWrapper, account.getTransactions());
         }
 
         saveTransactionToGenerateTransactionId(levyTxn);


### PR DESCRIPTION
https://fiterio.atlassian.net/browse/FSP-28
This pull request improves how the EMT Levy is handled for non-backdated transactions in the `PaystackSavingsAccountDomainServiceJpa.java` service. The main enhancement is the explicit calculation and setting of the running balance after the levy is applied, ensuring the account summary accurately reflects the deduction.

**Transaction handling improvements:**

* For non-backdated EMT Levy transactions, the code now calculates the new running balance by subtracting the levy amount from the current balance and sets it on the transaction (`levyTxn`).
* The account summary is updated using the correct set of transactions (`getTransactions()`), ensuring the summary reflects the latest deduction.